### PR TITLE
feat: support multi-sort keys in cursor pagination, non-unique keys

### DIFF
--- a/lib/pg_gen/macros/schema.ex
+++ b/lib/pg_gen/macros/schema.ex
@@ -92,6 +92,10 @@ defmodule PgGen.Schema do
     generate_strings(:allow_list, contents)
   end
 
+  defmacro non_unique_sort_fields(contents) do
+    generate_strings(:non_unique_sort_fields, contents)
+  end
+
   defmacro import_types(contents) do
     generate_strings(:imports, contents)
   end


### PR DESCRIPTION
@Ali-Kalout I think this PR should address our issues w/sorting objects... please take a look and test all of our queries that paginate against it. 

If you have time, it would also be nice to create that schema extension I suggested, but I'm also completely fine with hard-coding the `:rank` in their for now... we're the only users of this library!