### PR TITLE
remove unused Repo alias from tables

### DIFF
--- a/lib/ecto_gen/table_generator.ex
+++ b/lib/ecto_gen/table_generator.ex
@@ -191,7 +191,7 @@ defmodule EctoGen.TableGenerator do
        @derive {Jason.Encoder, only: @pg_columns}
 
        alias #{app_name}.Repo
-       alias #{app_name}.Repo.{#{aliases}}
+       #{if not Enum.empty?(aliases), do: "alias #{app_name}.Repo.{#{aliases}}", else: ""}
 
        @schema_prefix "#{schema}"
        #{if primary_key_type, do: "@primary_key {:id, #{primary_key_type}, autogenerate: false}", else: "@primary_key false"}


### PR DESCRIPTION
lmk if this makes sense. Trying to remove some of the warnings generated from unused aliases.